### PR TITLE
chore: rip.md tweaks

### DIFF
--- a/src/content/docs/eips/layer2/rip.mdx
+++ b/src/content/docs/eips/layer2/rip.mdx
@@ -4,7 +4,8 @@ description: Rollup Improvement Proposals
 ---
 
 Rollup Improvement Proposals are formal updates to all the Rollups in the Ethereum Ecosystem. 
-[RIP-7212: Precompiled for secp256r1 Curve Support](https://eips.ethereum.org/EIPS/eip-7212)
+
+[RIP-7212: Precompile for secp256r1 Curve Support](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)
 
 [RIP-7560: Native Account Abstraction](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7560.md)
 


### PR DESCRIPTION
Minor fixes: 

- `RIP-7212` link should point to `Rollup Improvement proposal` repo instead of `Ethereum Improvement Proposal` repo. 
- Title is `Precompile...` not `Precompiled...`. 
- Renames  `rip.md` to `rip.mdx` to match convention used by other pages.