### PR TITLE
chore(analytics): add outbound links to Plausible

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
                     {
                       tag: 'script',
                       attrs: {
-                        src: 'https://plausible.io/js/script.js',
+                        src: 'https://plausible.io/js/script.outbound-links.js',
                         defer: true,
                         'data-domain': 'eips.wiki',
                       },


### PR DESCRIPTION
### What does this  pull request do?

Tweaks existing Plausible integration to also track outbound links.

At this point majority of links in a wiki lead to EIP definition hosted on external sites. 

It is worth knowing if we are good at directing traffic towards those sites.

### How can this be manually tested?

After PR is merged visit the site and click on link leading to some external site. 

#### Checklist

- [x] I have reviewed my submission and its follows the project's guidelines.
